### PR TITLE
Fixes the labeler action trigger to allow write permission

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the labeler trigger based on the documentation https://github.com/actions/labeler?tab=readme-ov-file#permissions.


### Testing Strategy

This pull request was tested by using this PR.


### TODO or Help Wanted

N/A


### Build

- [x] Ran `npm build`.

### Author

Signed-off-by: Alexandru Radovici <alexandru.radovici@upb.ro>
