### PR TITLE
Wrong example for not operator

### DIFF
--- a/docs/devoir/02.md
+++ b/docs/devoir/02.md
@@ -141,7 +141,7 @@ Exemples:
 2*4+5;
 variable+5;
 2+(x+y)*(exec func());
-!true;
+not true;
 ```
 
 ### Déclarations des variables


### PR DESCRIPTION
The operator used in the example is `!` instead of `not`. If it should be the other way around, please rectify,

