### PR TITLE
Update 02.md - not operator

### DIFF
--- a/docs/devoir/02.md
+++ b/docs/devoir/02.md
@@ -130,7 +130,7 @@ Priorité des opérateurs
 |-|-|
 | `*`, `/`, `mod` | Haute|
 | `+`, `-`| |
-|`not` | |
+|`!` (`not` logique) | |
 |`and`, `or`, `xor` | |
 | `>`, `>=`, `<`, `<=`| |
 |`==`, `!=`| Bas |


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the `not` operator in the Devoir 2 text. It should be marked as `!`, not the `not` keyword.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Build

- [ ] Ran `npm build`.

### Author

Signed-off-by: Mihai Costin <mihaicostin342@gmail.com>
